### PR TITLE
Upgrade flow_parser to package to 0.47.0

### DIFF
--- a/Fastpack/Analyze.ml
+++ b/Fastpack/Analyze.ml
@@ -1,8 +1,8 @@
 let analyze _id filename source =
   let (program, _errors) = Parser_flow.program_file source None in
-  let module S = Spider_monkey_ast.Statement in
-  let module E = Spider_monkey_ast.Expression in
-  let module L = Spider_monkey_ast.Literal in
+  let module S = Ast.Statement in
+  let module E = Ast.Expression in
+  let module L = Ast.Literal in
 
   let dependencies = ref [] in
   let dependency_id = ref 0 in
@@ -12,12 +12,12 @@ let analyze _id filename source =
   let add_patch offset_start offset_end patch =
     (* TODO: refactor to use the make_patcher API *)
     workspace := Workspace.patch !workspace {
-      Workspace.
-      patch;
-      offset_start;
-      offset_end;
-      order=0;
-    }
+        Workspace.
+        patch;
+        offset_start;
+        offset_end;
+        order=0;
+      }
   in
 
   let dependency_to_module_id ctx dep =
@@ -59,11 +59,11 @@ let analyze _id filename source =
         dependency_id := !dependency_id + 1;
         dependencies := dep::!dependencies;
         add_patch loc.start.offset loc._end.offset (fun ctx ->
-          let module_id = dependency_to_module_id ctx dep in
-          Printf.sprintf "__fastpack_require__(/* \"%s\" */ \"%s\")"
-                         dep.request
-                         module_id
-        );
+            let module_id = dependency_to_module_id ctx dep in
+            Printf.sprintf "__fastpack_require__(/* \"%s\" */ \"%s\")"
+              dep.request
+              module_id
+          );
       | _ ->
         ()
     in Visit.Continue

--- a/Fastpack/Printer.ml
+++ b/Fastpack/Printer.ml
@@ -1,10 +1,10 @@
-module Expression = Spider_monkey_ast.Expression
-module Pattern = Spider_monkey_ast.Pattern
-module Statement = Spider_monkey_ast.Statement
-module Literal = Spider_monkey_ast.Literal
-module Type = Spider_monkey_ast.Type
-module Variance = Spider_monkey_ast.Variance
-module Class = Spider_monkey_ast.Class
+module Expression = Ast.Expression
+module Pattern = Ast.Pattern
+module Statement = Ast.Statement
+module Literal = Ast.Literal
+module Type = Ast.Type
+module Variance = Ast.Variance
+module Class = Ast.Class
 
 (** Printer context *)
 type printer_ctx = {
@@ -309,6 +309,9 @@ let print program =
 
   and emit_expression ((loc, expression) : Expression.t) ctx =
     match expression with
+    | Expression.Import _ ->
+      (** TODO: handle import() *)
+      ctx
     | Expression.This -> ctx |> emit "this"
     | Expression.Super -> ctx |> emit "super"
     | Expression.Array { elements } ->
@@ -514,7 +517,7 @@ let print program =
       ctx |> emit "[" |> emit_expression expr |> emit "]"
 
   and emit_function ?(as_method=false) ?emit_id (_loc, {
-      Spider_monkey_ast.Function.
+      Ast.Function.
       id;
       params;
       body;
@@ -539,15 +542,15 @@ let print program =
       let (params, rest) = params in fun ctx ->
         ctx
         |> emit_list ~emit_sep:emit_comma emit_pattern params
-        |> emit_if_some (fun (_loc, { Spider_monkey_ast.Function.RestElement.  argument }) ctx ->
+        |> emit_if_some (fun (_loc, { Ast.Function.RestElement.  argument }) ctx ->
             ctx |> emit " ..." |> emit_pattern argument) rest
     )
     |> emit ")"
     |> emit_if_some emit_type_annotation returnType
     |> emit_space
     |> (match body with
-        | Spider_monkey_ast.Function.BodyBlock block -> emit_block block
-        | Spider_monkey_ast.Function.BodyExpression expr -> emit_expression expr)
+        | Ast.Function.BodyBlock block -> emit_block block
+        | Ast.Function.BodyExpression expr -> emit_expression expr)
 
   and emit_type_annotation (_loc, typeAnnotation) ctx =
     ctx |> emit ": " |> emit_type typeAnnotation
@@ -565,7 +568,7 @@ let print program =
     |> dedent
     |> emit "}"
 
-  and emit_identifier ((_loc, identifier) : Spider_monkey_ast.Identifier.t) =
+  and emit_identifier ((_loc, identifier) : Ast.Identifier.t) =
     emit identifier
 
   and emit_variable_declaration _value ctx =
@@ -629,7 +632,7 @@ let print program =
     emit raw ctx
   in
 
-  let emit_program ((_, statements, _): Spider_monkey_ast.program) ctx =
+  let emit_program ((_, statements, _): Ast.program) ctx =
     emit_list ~emit_sep:emit_semicolon_and_newline emit_statement statements ctx
   in
 

--- a/Fastpack/Visit.ml
+++ b/Fastpack/Visit.ml
@@ -1,11 +1,11 @@
-module Expression = Spider_monkey_ast.Expression
-module Pattern = Spider_monkey_ast.Pattern
-module Statement = Spider_monkey_ast.Statement
-module Literal = Spider_monkey_ast.Literal
-module Type = Spider_monkey_ast.Type
-module Variance = Spider_monkey_ast.Variance
-module Class = Spider_monkey_ast.Class
-module Function = Spider_monkey_ast.Function
+module Expression = Ast.Expression
+module Pattern = Ast.Pattern
+module Statement = Ast.Statement
+module Literal = Ast.Literal
+module Type = Ast.Type
+module Variance = Ast.Variance
+module Class = Ast.Class
+module Function = Ast.Function
 
 
 type visit_action = Continue | Break
@@ -175,6 +175,7 @@ and visit_expression handler ((loc, expression) : Expression.t) =
   | Break -> ()
   | Continue ->
     match expression with
+    | Expression.Import _ -> ()
     | Expression.This -> ()
     | Expression.Super -> ()
     | Expression.Array { elements } ->
@@ -289,11 +290,11 @@ and visit_pattern (handler : visit_handler) ((_loc, pattern) as p : Pattern.t) =
     | Pattern.Expression expr -> visit_expression handler expr
 
 and visit_object_property handler (_, {
-               key;
-               value;
-               _method;
-               shorthand = _shorthand;
-             }) =
+    key;
+    value;
+    _method;
+    shorthand = _shorthand;
+  }) =
   match value with
   | Expression.Object.Property.Init expr ->
     visit_object_property_key handler key;
@@ -350,10 +351,10 @@ and visit_variable_declaration handler (_, { declarations; kind = _kind }) =
     declarations;
 
 and visit_variable_declarator handler (_, { init; id }) =
-   visit_pattern handler id;
-   (match init with
-    | None  -> ();
-    | Some expr -> visit_expression handler expr);
+  visit_pattern handler id;
+  (match init with
+   | None  -> ();
+   | Some expr -> visit_expression handler expr);
 
 and visit_expression_or_spread handler item = match item with
   | Expression.Expression expression -> visit_expression handler expression
@@ -362,7 +363,7 @@ and visit_expression_or_spread handler item = match item with
 
 let visit handler program =
 
-  let visit_program ((_, statements, _): Spider_monkey_ast.program) =
+  let visit_program ((_, statements, _): Ast.program) =
     visit_list handler visit_statement statements
   in
 

--- a/FastpackTranspiler/Flow.ml
+++ b/FastpackTranspiler/Flow.ml
@@ -1,11 +1,11 @@
 module Visit = Fastpack.Visit
 module Workspace = Fastpack.Workspace
-module S = Spider_monkey_ast.Statement
-module E = Spider_monkey_ast.Expression
-module L = Spider_monkey_ast.Literal
-module P = Spider_monkey_ast.Pattern
-module F = Spider_monkey_ast.Function
-module C = Spider_monkey_ast.Class
+module S = Ast.Statement
+module E = Ast.Expression
+module L = Ast.Literal
+module P = Ast.Pattern
+module F = Ast.Function
+module C = Ast.Class
 
 let get_handler handler _ _ { Workspace. sub; patch_loc; remove_loc; remove; _} =
 
@@ -59,11 +59,11 @@ let get_handler handler _ _ { Workspace. sub; patch_loc; remove_loc; remove; _} 
   in
 
   let patch_class {C.
-        implements;
-        body=(_, {body});
-        typeParameters;
-        superTypeParameters; _
-      } =
+                    implements;
+                    body=(_, {body});
+                    typeParameters;
+                    superTypeParameters; _
+                  } =
     begin
       match implements with
       | [] -> ();
@@ -98,8 +98,8 @@ let get_handler handler _ _ { Workspace. sub; patch_loc; remove_loc; remove; _} 
 
       let maybe_comma_after (loc : Loc.t) =
         if is_last
-          then loc._end.offset
-          else match Util.find_comma_pos ~direction:Util.GoForward sub loc._end.offset with
+        then loc._end.offset
+        else match Util.find_comma_pos ~direction:Util.GoForward sub loc._end.offset with
           | Some pos -> pos
           | None -> loc._end.offset
       in
@@ -140,7 +140,7 @@ let get_handler handler _ _ { Workspace. sub; patch_loc; remove_loc; remove; _} 
       if List.for_all
           (patch_specifier @@ List.length specifiers)
           (List.mapi (fun i s -> (i, s)) specifiers)
-        then remove_loc loc;
+      then remove_loc loc;
   in
 
   let visit_expression (_, expr) =
@@ -173,8 +173,8 @@ let get_handler handler _ _ { Workspace. sub; patch_loc; remove_loc; remove; _} 
     | S.VariableDeclaration { declarations; _ } ->
       List.iter
         (fun declarator ->
-          let (_, { S.VariableDeclaration.Declarator. id; _ }) = declarator in
-          patch_pattern id
+           let (_, { S.VariableDeclaration.Declarator. id; _ }) = declarator in
+           patch_pattern id
         )
         declarations;
       Visit.Continue;

--- a/FastpackTranspiler/Spread.ml
+++ b/FastpackTranspiler/Spread.ml
@@ -1,10 +1,10 @@
 module Visit = Fastpack.Visit
 module Workspace = Fastpack.Workspace
-module S = Spider_monkey_ast.Statement
-module E = Spider_monkey_ast.Expression
-module L = Spider_monkey_ast.Literal
-module P = Spider_monkey_ast.Pattern
-module F = Spider_monkey_ast.Function
+module S = Ast.Statement
+module E = Ast.Expression
+module L = Ast.Literal
+module P = Ast.Pattern
+module F = Ast.Function
 
 type pattern_action = Drop
                     | Patch of (int * int * string) list
@@ -28,12 +28,12 @@ let get_handler handler transpile_source scope
   in
 
   let rec pattern_has_rest ({ properties; _ } : P.Object.t)  = List.exists
-    (fun prop -> match prop with
-      | P.Object.RestProperty _ -> true
-      | P.Object.Property (_, { pattern = (_, P.Object pattern); _}) ->
-        pattern_has_rest pattern
-      | P.Object.Property _ -> false
-    ) properties
+      (fun prop -> match prop with
+         | P.Object.RestProperty _ -> true
+         | P.Object.Property (_, { pattern = (_, P.Object pattern); _}) ->
+           pattern_has_rest pattern
+         | P.Object.Property _ -> false
+      ) properties
   in
 
   let rec pattern_action object_name (object_pattern: P.Object.t) =
@@ -102,17 +102,17 @@ let get_handler handler transpile_source scope
 
       | P.Object.RestProperty (_, {argument = (loc, _)}) ->
         after := !after
-          @ [(sub_loc loc)
-             ^ " = " ^ (Util.removeProps object_name !remove_props)
-            ];
+                 @ [(sub_loc loc)
+                    ^ " = " ^ (Util.removeProps object_name !remove_props)
+                   ];
         Drop
     in
     let {P.Object. properties; _} = object_pattern in
     let property_actions = List.map property_action properties in
     let drop_all = List.for_all
         (fun action -> match action with
-          | Drop -> true
-          | _ -> false)
+           | Drop -> true
+           | _ -> false)
         property_actions
     in
     let action = if drop_all
@@ -123,8 +123,8 @@ let get_handler handler transpile_source scope
           let start = if is_first
             then loc.start.offset
             else match Util.find_comma_pos sub loc.start.offset with
-            | Some pos -> pos
-            | None -> loc.start.offset
+              | Some pos -> pos
+              | None -> loc.start.offset
           in
           (start, loc._end.offset - start, "")
         in
@@ -132,13 +132,13 @@ let get_handler handler transpile_source scope
           List.flatten
           @@ List.mapi
             (fun i prop ->
-              match List.nth property_actions i with
-              | Patch patches -> patches
-              | Drop -> match prop with
-                | P.Object.RestProperty (loc, _) ->
-                  [ maybe_comma (i = 0) loc ]
-                | P.Object.Property (loc, _) ->
-                  [ maybe_comma (i = 0) loc ]
+               match List.nth property_actions i with
+               | Patch patches -> patches
+               | Drop -> match prop with
+                 | P.Object.RestProperty (loc, _) ->
+                   [ maybe_comma (i = 0) loc ]
+                 | P.Object.Property (loc, _) ->
+                   [ maybe_comma (i = 0) loc ]
             )
             properties
         in Patch patches
@@ -152,8 +152,8 @@ let get_handler handler transpile_source scope
     let params_with_rest =
       List.map
         (fun (_, p) -> match p with
-          | P.Object pattern -> pattern_has_rest pattern
-          | _ -> false
+           | P.Object pattern -> pattern_has_rest pattern
+           | _ -> false
         )
         params
     in
@@ -166,22 +166,22 @@ let get_handler handler transpile_source scope
     in
     if (List.exists (fun x -> x) params_with_rest) || rest_has_rest then begin
       let param_patches = List.fold_left2
-        (fun result has_rest param ->
-          match has_rest, param with
-          | true, (loc, P.Object _) ->
-            let name = tmp_var () in
-            let _, assignment = transpile_assignment (sub_loc loc) name in
-            begin
-              patch_loc loc name;
-              result @ [assignment]
-            end
-          | _ ->
-            Visit.visit_pattern handler param;
-            result
-        )
-        ([] : string list)
-        params_with_rest
-        params
+          (fun result has_rest param ->
+             match has_rest, param with
+             | true, (loc, P.Object _) ->
+               let name = tmp_var () in
+               let _, assignment = transpile_assignment (sub_loc loc) name in
+               begin
+                 patch_loc loc name;
+                 result @ [assignment]
+               end
+             | _ ->
+               Visit.visit_pattern handler param;
+               result
+          )
+          ([] : string list)
+          params_with_rest
+          params
       in
       let rest_patches =
         if rest_has_rest then
@@ -228,12 +228,12 @@ let get_handler handler transpile_source scope
           ) properties
         in
         if has_rest then
-        begin
-          let name, r_value = new_name @@ sub_loc loc_right in
-          let _, rest = transpile_assignment (sub_loc loc_left) name in
-          patch_loc loc @@ Printf.sprintf "(%s, %s)" r_value rest;
-          Visit.Break
-        end
+          begin
+            let name, r_value = new_name @@ sub_loc loc_right in
+            let _, rest = transpile_assignment (sub_loc loc_left) name in
+            patch_loc loc @@ Printf.sprintf "(%s, %s)" r_value rest;
+            Visit.Break
+          end
         else
           Visit.Continue
       end
@@ -246,24 +246,24 @@ let get_handler handler transpile_source scope
       if has_spread properties
       then
         begin
-        patch loc.start.offset 1 "Object.assign({},";
-        Visit.visit_list
-          handler
-          (fun handler prop ->
-            match prop with
-            | E.Object.SpreadProperty (loc, {argument}) ->
-              remove loc.start.offset 3;
-              Visit.visit_expression handler argument
-            | E.Object.Property p ->
-              let (loc, _) = p in
-              begin
-                patch loc.start.offset 0 "{";
-                Visit.visit_object_property handler p;
-                patch loc._end.offset 0 "}"
-              end)
-          properties;
-        patch loc._end.offset (-1) ")";
-        Visit.Break
+          patch loc.start.offset 1 "Object.assign({},";
+          Visit.visit_list
+            handler
+            (fun handler prop ->
+               match prop with
+               | E.Object.SpreadProperty (loc, {argument}) ->
+                 remove loc.start.offset 3;
+                 Visit.visit_expression handler argument
+               | E.Object.Property p ->
+                 let (loc, _) = p in
+                 begin
+                   patch loc.start.offset 0 "{";
+                   Visit.visit_object_property handler p;
+                   patch loc._end.offset 0 "}"
+                 end)
+            properties;
+          patch loc._end.offset (-1) ")";
+          Visit.Break
         end
       else
         Visit.Continue
@@ -291,26 +291,26 @@ let get_handler handler transpile_source scope
         match left with
         | S.ForOf.LeftDeclaration (_, {declarations; _}) ->
           let patches = List.fold_left
-            (fun patches declarator ->
-              let (loc, { S.VariableDeclaration.Declarator. id; _}) = declarator in
-              let has_rest = match id with
-                | (_, P.Object pattern) -> pattern_has_rest pattern
-                | _ -> false
-              in
-              match has_rest, id  with
-              | true, (id_loc, P.Object _) ->
-                let name = tmp_var () in
-                let _, assignment = transpile_assignment (sub_loc loc) name in
-                begin
-                  patch_loc id_loc name;
-                  patches @ [assignment]
-                end;
-              | _ ->
-                Visit.visit_variable_declarator handler declarator;
-                []
-            )
-            []
-            declarations
+              (fun patches declarator ->
+                 let (loc, { S.VariableDeclaration.Declarator. id; _}) = declarator in
+                 let has_rest = match id with
+                   | (_, P.Object pattern) -> pattern_has_rest pattern
+                   | _ -> false
+                 in
+                 match has_rest, id  with
+                 | true, (id_loc, P.Object _) ->
+                   let name = tmp_var () in
+                   let _, assignment = transpile_assignment (sub_loc loc) name in
+                   begin
+                     patch_loc id_loc name;
+                     patches @ [assignment]
+                   end;
+                 | _ ->
+                   Visit.visit_variable_declarator handler declarator;
+                   []
+              )
+              []
+              declarations
           in
           patch_body patches;
         | S.ForOf.LeftExpression (loc, E.Object {properties}) -> ();
@@ -320,55 +320,55 @@ let get_handler handler transpile_source scope
             ) properties
           in
           if has_spread properties then
-          let name = tmp_var () in
-          let _, assignment = transpile_assignment (sub_loc loc) name in
-          begin
-            patch_loc loc name;
-            patch_body [assignment];
-          end;
+            let name = tmp_var () in
+            let _, assignment = transpile_assignment (sub_loc loc) name in
+            begin
+              patch_loc loc name;
+              patch_body [assignment];
+            end;
         | _ -> ();
       end;
       Visit.Break;
     | S.VariableDeclaration { declarations; _ } ->
       List.iter
         (fun declarator ->
-          let (loc, { S.VariableDeclaration.Declarator. id; init }) = declarator in
-          let has_rest = match id with
-            | (_, P.Object pattern) -> pattern_has_rest pattern
-            | _ -> false
-          in
-          match has_rest, id, init with
-          | true, (id_loc, P.Object pattern), Some (init_loc, init_expr) ->
-            let object_name =
-              match init_expr with
-              | E.Identifier (_,name) -> name
-              | _ ->
-                let name, value = new_name @@ sub_loc init_loc in
-                begin
-                  patch id_loc.start.offset 0 @@ value ^ ", ";
-                  name
-                end
-            in
-            let action, before, after =
-              pattern_action object_name pattern
-            in
-            let s_before = String.concat ", " before in
-            let s_after = String.concat ", " after in
-            begin
-              match action with
-              | Drop ->
-                patch_loc loc @@ String.concat ", " @@ before @ after
-              | Patch patches ->
-                if s_before <> "" then
-                  patch id_loc.start.offset 0 @@ s_before ^ ", ";
-                List.iter
-                  (fun (start, offset, s) -> patch start offset s) patches;
-                if object_name != (sub_loc init_loc)
-                  then patch_loc init_loc object_name;
-                patch init_loc._end.offset 0 @@ ", " ^ s_after
-            end
-          | _ ->
-            Visit.visit_variable_declarator handler declarator
+           let (loc, { S.VariableDeclaration.Declarator. id; init }) = declarator in
+           let has_rest = match id with
+             | (_, P.Object pattern) -> pattern_has_rest pattern
+             | _ -> false
+           in
+           match has_rest, id, init with
+           | true, (id_loc, P.Object pattern), Some (init_loc, init_expr) ->
+             let object_name =
+               match init_expr with
+               | E.Identifier (_,name) -> name
+               | _ ->
+                 let name, value = new_name @@ sub_loc init_loc in
+                 begin
+                   patch id_loc.start.offset 0 @@ value ^ ", ";
+                   name
+                 end
+             in
+             let action, before, after =
+               pattern_action object_name pattern
+             in
+             let s_before = String.concat ", " before in
+             let s_after = String.concat ", " after in
+             begin
+               match action with
+               | Drop ->
+                 patch_loc loc @@ String.concat ", " @@ before @ after
+               | Patch patches ->
+                 if s_before <> "" then
+                   patch id_loc.start.offset 0 @@ s_before ^ ", ";
+                 List.iter
+                   (fun (start, offset, s) -> patch start offset s) patches;
+                 if object_name != (sub_loc init_loc)
+                 then patch_loc init_loc object_name;
+                 patch init_loc._end.offset 0 @@ ", " ^ s_after
+             end
+           | _ ->
+             Visit.visit_variable_declarator handler declarator
         )
         declarations;
       Visit.Break

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-Fastpack:
 bootstrap: install conf-merlin build
 
 install:
-	@opam install -y ocp-indent flow_parser=0.40.0 fileutils cmdliner
+	@opam install -y ocp-indent flow_parser fileutils cmdliner
 	@opam pin add --dev-repo lwt
 	@opam pin add merlin 'https://github.com/ocaml/merlin.git#beta'
 

--- a/bin/jbuild
+++ b/bin/jbuild
@@ -4,6 +4,6 @@
  ((names (fpack fpack_test))
   (public_names (fpack fpack_test))
   (package Fastpack)
-  (libraries (Fastpack FastpackTranspiler FastpackResolver cmdliner lwt.unix flow_parser fileutils yojson))
+  (libraries (Fastpack FastpackTranspiler FastpackResolver cmdliner lwt.unix sedlex flow_parser fileutils yojson))
   (preprocess (pps (lwt.ppx)))))
 


### PR DESCRIPTION
This fixes some of the hiccups with the location tracking that @zindel found. Though it also introduces some more issues.

This is what test run reports now:
```
❯❯❯❯ make test                                                                                                                ~/W/fastpack
object-spread-and-rest-operators.js
-------------------
strip-flow.js
-------------------
30,31c30,31
< class C2 {
< class C3 {
---
> class C2 {  }
> class C3 {  }
70,74c70,74
<
<
<
<
<
---
> ;
> ;
> ;
> ;
> ;
239a240,245
>
> /* Babel: strip-typecasts */
> (xxx: number);
> ({ xxx: 0, yyy: "hey" }: { xxx: number; yyy: string });
> (xxx => xxx + 1: (xxx: number) => number);
> ((xxx: number), (yyy: string));


FAIL. 1 failed of 2 total.
```

Oleksiy, can you confirm that the issue with location is fixed now?