### PR TITLE
Replace colordiff by git diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ examples/*/fpack-test/*.js
 examples/*/.cache
 .DS_Store
 fpack-test
+esy.lock
+flow/

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ examples/*/fpack-test/*.js
 examples/*/.cache
 .DS_Store
 fpack-test
-esy.lock
-flow/

--- a/README.md
+++ b/README.md
@@ -8,35 +8,49 @@ Pack JS code into a single bundle fast & easy.
 
 Make sure you have `esy` installed:
 
-    % npm install -g esy
+```bash
+npm install -g esy
+```
 
 Now install dependencies & build everything:
 
-    % make bootstrap
+```bash
+make bootstrap
+```
 
 Then to produce the executable:
 
-    % make build
+```bash
+make build
+```
 
 To run tests:
 
-    % make test
+```bash
+make test
+```
 
 To test compiled executables prepend with `esy x`:
 
-    % esy x fpack
+```bash
+esy x fpack
+```
 
 As merlin and others live inside sandboxed environment you'd want to execute
 your editor from inside it:
 
-    % esy vim
-    % esy nvim
-    % esy vscode
-    % esy sublime
+```bash
+esy vim
+esy nvim
+esy vscode
+esy sublime
+```
 
 Alternatively you can enter into sandboxed shell:
 
-    % esy shell
+```bash
+esy shell
+```
 
 And execute commands from there.
 

--- a/bin/fpack_test.ml
+++ b/bin/fpack_test.ml
@@ -185,7 +185,7 @@ let () =
     let show_diff name actual =
       let temp_file = Filename.temp_file "" ".result.js" in
       let _ = write_file temp_file actual in
-      let cmd = "colordiff " ^ name ^ " " ^ temp_file in
+      let cmd = "git diff --color " ^ name ^ " " ^ temp_file in
       let%lwt output = Lwt_process.(pread @@ shell cmd) in
       Lwt.finalize
         (fun () -> print output)


### PR DESCRIPTION
Hi,

I tried to run tests but had not colordiff binary installed on my machine (OS X).
Maybe we could replace this binary by git diff considering user has git anyway ?