### PR TITLE
Fix default output and specify it in help

### DIFF
--- a/Fastpack/Fastpack.ml
+++ b/Fastpack/Fastpack.ml
@@ -44,7 +44,7 @@ let empty_options = {
 let default_options =
   {
     input = Some "index.js";
-    output = Some "./bundle/bundle.js";
+    output = Some "./bundle";
     mode = Some Production;
     target = Some Application;
     cache = Some Normal;

--- a/bin/fpack.ml
+++ b/bin/fpack.ml
@@ -60,7 +60,7 @@ let () =
     let output_t =
       let doc =
         "Output Directory. "
-        ^ "The target bundle will be $(docv)/index.js"
+        ^ "The target bundle will be $(docv)/index.js. 'bundle' is used by default"
       in
       let docv = "DIR" in
       Arg.(value & opt (some string) None & info ["o"; "output"] ~docv ~doc)


### PR DESCRIPTION
Currently bundle by default is written to `bundle/bundle.js/index.js` file.