### PR TITLE
Rename project_dir to current_dir in code

### DIFF
--- a/Fastpack/FlatPacker.ml
+++ b/Fastpack/FlatPacker.ml
@@ -45,7 +45,7 @@ let pack (cache : Cache.t) (ctx : Context.t) result_channel =
   in
 
   let gen_wrapper_binding location =
-    let module_id = Module.make_id ctx.project_dir location in
+    let module_id = Module.make_id ctx.current_dir location in
     Printf.sprintf "$w__%s" module_id
   in
 
@@ -228,7 +228,7 @@ let pack (cache : Cache.t) (ctx : Context.t) result_channel =
                     then
                       let location_str =
                         Module.location_to_string
-                          ~base_dir:(Some ctx.project_dir)
+                          ~base_dir:(Some ctx.current_dir)
                           m.location
                       in
                       raise (PackError (ctx, CannotFindExportedName (remote, location_str)))

--- a/Fastpack/RegularPacker.ml
+++ b/Fastpack/RegularPacker.ml
@@ -170,7 +170,7 @@ let pack (cache : Cache.t) (ctx : Context.t) output_channel =
       | ExportFinder.Yes | ExportFinder.Maybe -> ()
       | ExportFinder.No ->
         let location_str =
-          Module.location_to_string ~base_dir:(Some ctx.project_dir) m.location
+          Module.location_to_string ~base_dir:(Some ctx.current_dir) m.location
         in
         raise (PackError (ctx, CannotFindExportedName (name, location_str)))
     in
@@ -801,7 +801,7 @@ process = { env: {} };
             ~workspace
             ~ctx:(m, dep_map) in
         let%lwt () =
-          Module.location_to_string ~base_dir:(Some ctx.project_dir) m.location
+          Module.location_to_string ~base_dir:(Some ctx.current_dir) m.location
           |> Printf.sprintf "\\n//# sourceURL=fpack:///%s\");"
           |> emit
         in

--- a/Fastpack/Resolver.mli
+++ b/Fastpack/Resolver.mli
@@ -12,7 +12,7 @@ type t = {
 
 exception Error of string
 
-val make : project_dir:string ->
+val make : current_dir:string ->
            mock:(string * Mock.t) list ->
            node_modules_paths:string list ->
            extensions:string list ->

--- a/FastpackTest/Resolver.ml
+++ b/FastpackTest/Resolver.ml
@@ -34,7 +34,7 @@ let show resolved =
   Format.flush_str_formatter ()
 
 let resolve
-  ?(project_dir=test_path)
+  ?(current_dir=test_path)
   ?(mock=[])
   ?(node_modules_paths=["node_modules"])
   ?(extensions=[".js"; ".json"])
@@ -42,12 +42,12 @@ let resolve
   ?(basedir=test_path)
   request
   =
-    let basedir = FS.abs_path project_dir basedir in
+    let basedir = FS.abs_path current_dir basedir in
     let resolve' () =
       let%lwt cache = Fastpack.Cache.(create Memory) in
       let { resolve } =
         make
-          ~project_dir
+          ~current_dir
           ~mock
           ~node_modules_paths
           ~extensions

--- a/esy.lock
+++ b/esy.lock
@@ -614,10 +614,10 @@
   peerDependencies:
     ocaml " >= 4.4.1000"
 
-"@opam/ppxlib@ >= 0.1.0", "@opam/ppxlib@ >= 0.1.0  <= 0.2.0":
+"@opam/ppxlib@ >= 0.1.0", "@opam/ppxlib@ >= 0.1.0  < 0.3.0", "@opam/ppxlib@0.2.0":
   version "0.2.0"
   uid "93d82ced03be89fddafba96a102130b6"
-  resolved "@opam/ppxlib@0.2.0-13c15ee8edd6fa714c280cdc3fb9326c.tgz"
+  resolved "@opam/ppxlib@0.2.0-93d82ced03be89fddafba96a102130b6.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"

--- a/esy.lock
+++ b/esy.lock
@@ -425,7 +425,7 @@
 
 "@opam/ppx_compare@ >= 100000000.11.0  < 100000000.12.0":
   version "100000000.11.0"
-  uid a5b1d7c2186e091f0ea69284eed6c137
+  uid "3bd5aced00a182128b071a2e63901190"
   resolved "@opam/ppx_compare@100000000.11.0-6151234c2bed40a7efd973b46eab4149.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -433,7 +433,7 @@
     "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
     "@opam/jbuilder" " >= 1.0.0-beta181"
     "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
-    "@opam/ppxlib" " >= 0.1.0  <= 0.2.0"
+    "@opam/ppxlib" " >= 0.1.0  < 0.3.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
@@ -564,7 +564,7 @@
 
 "@opam/ppx_sexp_conv@ >= 100000000.11.0  < 100000000.12.0":
   version "100000000.11.0"
-  uid b1dfc78c4705a1a75a29cb1c17f3e948
+  uid ffc715db36865abe7794aceeb46a5e1d
   resolved "@opam/ppx_sexp_conv@100000000.11.0-4fe1e425c5ca6250f1047e918d9cacb6.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -572,7 +572,7 @@
     "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
     "@opam/jbuilder" " >= 1.0.0-beta181"
     "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
-    "@opam/ppxlib" " >= 0.1.0  <= 0.2.0"
+    "@opam/ppxlib" " >= 0.1.0  < 0.3.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
@@ -601,7 +601,7 @@
 
 "@opam/ppx_variants_conv@ >= 100000000.11.0  < 100000000.12.0":
   version "100000000.11.0"
-  uid a915d2095cdb030d738864e6df504bcc
+  uid "6d0972d637a41690660801b5c72dfe65"
   resolved "@opam/ppx_variants_conv@100000000.11.0-31aa55282c987d27035065a517f14d44.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -609,14 +609,14 @@
     "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
     "@opam/jbuilder" " >= 1.0.0-beta181"
     "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
-    "@opam/ppxlib" " >= 0.1.0  <= 0.2.0"
+    "@opam/ppxlib" " >= 0.1.0  < 0.3.0"
     "@opam/variantslib" " >= 100000000.11.0  < 100000000.12.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
 "@opam/ppxlib@ >= 0.1.0", "@opam/ppxlib@ >= 0.1.0  <= 0.2.0":
   version "0.2.0"
-  uid "13c15ee8edd6fa714c280cdc3fb9326c"
+  uid "93d82ced03be89fddafba96a102130b6"
   resolved "@opam/ppxlib@0.2.0-13c15ee8edd6fa714c280cdc3fb9326c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -694,7 +694,7 @@
 
 "@opam/sequence@*":
   version "1.0.0"
-  uid c7ee13c8a8625f72cde85a522db6e3cb
+  uid ee28c9ab135576d1b2167cf4c3137274
   resolved "@opam/sequence@1.0.0-c7ee13c8a8625f72cde85a522db6e3cb.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -703,7 +703,7 @@
     "@opam/jbuilder" " >= 1.0.0-beta12"
     "@opam/result" "*"
   peerDependencies:
-    ocaml "*"
+    ocaml " < 4.7.0"
 
 "@opam/sexplib0@ >= 100000000.11.0  < 100000000.12.0":
   version "100000000.11.0"
@@ -754,7 +754,7 @@
 
 "@opam/utop@^2.0.2":
   version "2.1.0"
-  uid "52ddf36354cf7530843a68ffd29ed6ac"
+  uid "1cdb125d1fe88a786f78fdbd62b3d2de"
   resolved "@opam/utop@2.1.0-52ddf36354cf7530843a68ffd29ed6ac.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
@@ -770,7 +770,7 @@
     "@opam/ocamlfind" " >= 1.7.2"
     "@opam/react" " >= 1.0.0"
   peerDependencies:
-    ocaml " >= 4.2.3000"
+    ocaml " >= 4.2.3000  < 4.7.0"
 
 "@opam/variantslib@ >= 100000000.11.0  < 100000000.12.0":
   version "100000000.11.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/fastpack/fastpack#readme",
   "resolutions": {
-    "**/@opam/gen": "0.5.0"
+    "**/@opam/gen": "0.5.0",
+    "**/@opam/ppxlib": "0.2.0"
   },
   "dependencies": {
     "@esy-ocaml/esy-installer": "*",


### PR DESCRIPTION
This will allow us to introduce `project_root` option without confusion.