### PR TITLE
Error Messages: Suggest the browser implementation for a missing node lib

### DIFF
--- a/Fastpack/Context.ml
+++ b/Fastpack/Context.ml
@@ -42,5 +42,5 @@ exception ExitOK
 
 let string_of_error ctx error =
   Printf.sprintf
-    "\n%s"
+    "\n%s\n"
     (Error.to_string ctx.current_dir error)

--- a/Fastpack/Context.ml
+++ b/Fastpack/Context.ml
@@ -42,6 +42,5 @@ exception ExitOK
 
 let string_of_error ctx error =
   Printf.sprintf
-    "\n%s\n%s"
-    (to_string ctx)
+    "\n%s"
     (Error.to_string ctx.current_dir error)

--- a/Fastpack/Error.ml
+++ b/Fastpack/Error.ml
@@ -192,13 +192,12 @@ let to_string package_dir error =
     loc ^ message
 
   | CannotRenameModuleBinding (loc, id, dep) ->
-    Printf.sprintf "
-                            Cannot rename module binding:
-      %s %s
-        Import Request: %s
-      Typically, it means that you are trying to use the name before importing it in
+    Printf.sprintf "Cannot rename module binding:
+%s %s
+Import Request: %s
+Typically, it means that you are trying to use the name before importing it in
 the code.
-      "
+"
       (loc_to_string loc)
       id
       (Module.Dependency.to_string ~dir:(Some package_dir) dep)

--- a/Fastpack/Error.ml
+++ b/Fastpack/Error.ml
@@ -73,7 +73,8 @@ let get_codeframe ?(isTTY=false) (loc: Loc.t) lines =
   let codeframe = List.filter_map (fun (i, line) ->
       if startLine <= i  && i <= endLine then
         Some (i, line)
-      else None
+      else 
+        None
     ) lines
   in
   let maxLineNo = List.fold_left (fun n (i, _) -> max n i) 0 lines in

--- a/Fastpack/Error.ml
+++ b/Fastpack/Error.ml
@@ -132,24 +132,21 @@ let to_string package_dir error =
 
   | CannotResolveModule (_, dep) ->
     let isTTY = FastpackUtil.FS.isatty Unix.stderr in
-    let (error_title, location) = format_error_header ~isTTY ~subtitle: ("cannot resolve '" ^ dep.request ^ "'") (
+    let (error_title, error_path) = format_error_header ~isTTY ~subtitle: ("cannot resolve '" ^ dep.request ^ "'") (
         "Module resolution error:",
         Module.location_to_string dep.requested_from
       )
     in
     (match List.assoc_opt dep.request nodelibs with
-     | None -> String.concat "\n" [
-         error_title;
-         location;
-       ]
+     | None -> String.concat "\n" [ error_title; error_path; ]
      | Some None -> String.concat "\n" [
          error_title;
-         location;
+         error_path;
          "This looks like base node.js library which does not have any browser implementation we are aware of";
        ]
      | Some Some mock -> String.concat "\n" [
          error_title;
-         location;
+         error_path;
          "This looks like base node.js library and unlikely is required in the browser environment.";
          "If you still want to use it, first install the browser implementation with:";
          "";
@@ -176,10 +173,10 @@ let to_string package_dir error =
         "";
       ]
     in
-    let (error_title, location) = format_error_header ~isTTY ("Parse error", location_str) in
+    let (error_title, error_path) = format_error_header ~isTTY ("Parse error", location_str) in
     String.concat "\n" [
       error_title;
-      location;
+      error_path;
       "";
       String.concat "\n" (List.map (format_error isTTY) errors);
       "";

--- a/Fastpack/Error.ml
+++ b/Fastpack/Error.ml
@@ -1,7 +1,7 @@
 module Loc = FlowParser.Loc
 module Scope = FastpackUtil.Scope
 
-(* 
+(*
   assoc list of nodejs libs and their mock implementations
   as listed on: https://github.com/webpack/node-libs-browser
 *)
@@ -39,52 +39,62 @@ let nodelibs = [
   "util", Some "util";
   "vm", Some "vm-browserify";
   "zlib", Some "browserify-zlib";
-] 
+]
 
 type color = Cyan | Red | Black | White;;
 type font = Regular | Bold;;
 
-let print_with_color ?font:(font=Regular) str col = 
-  let col = match col with 
+let print_with_color ?(font=Regular) ?(isTTY=true) str col =
+  let col = match col with
     | Cyan -> "36"
     | Red -> "31"
     | Black -> "30"
     | White -> "37"
   in
-  let f = match font with 
+  let f = match font with
     | Regular -> "0"
     | Bold -> "1"
   in
-  "\027[" ^ f ^ ";" ^ col ^ "m" ^ str ^ "\027[0m"
+  if isTTY then
+    "\027[" ^ f ^ ";" ^ col ^ "m" ^ str ^ "\027[0m"
+  else
+    str
 
-let get_codeframe ?(isTTY=false) (loc: Loc.t) lines = 
+let format_error_header ?(isTTY=true) ?(subtitle="") (title, path) =
+  if isTTY then
+    (print_with_color title Red) ^ " " ^ subtitle,
+    print_with_color ~font: Bold path Cyan
+  else
+    title ^ " " ^ subtitle, path
+
+let get_codeframe ?(isTTY=false) (loc: Loc.t) lines =
   let startLine = max 0 (loc.start.line - 2) in
   let endLine = min (List.length lines) (loc._end.line + 1) in
-  let codeframe = List.filter_map (fun (i, line) -> 
-      if startLine <= i  && i <= endLine then 
-        Some (i, line) 
+  let codeframe = List.filter_map (fun (i, line) ->
+      if startLine <= i  && i <= endLine then
+        Some (i, line)
       else None
     ) lines
   in
   let maxLineNo = List.fold_left (fun n (i, _) -> max n i) 0 lines in
   let maxDigits = String.length (string_of_int maxLineNo) in
-  let formatted = List.map (fun (i, line) -> 
+  let formatted = List.map (fun (i, line) ->
       let isErrorLine = loc.start.line <= i && i <= loc._end.line in
       let lineNo = String.pad maxDigits (string_of_int i) in
       match isErrorLine, isTTY with
-      | false, _ -> lineNo ^ " │ " ^ line 
-      | true, false -> 
+      | false, _ -> lineNo ^ " │ " ^ line
+      | true, false ->
         let offset, length = (loc.start.column + 1), (loc._end.column - loc.start.column) in
         let whitespaceBeforeBar = String.repeat " " (maxDigits + 1) in
         let whitespaceAfterBar = String.repeat " " offset in
         let carets = String.repeat "^" length in
         lineNo ^ " │ " ^ line ^ "\n" ^ whitespaceBeforeBar ^ "│" ^ whitespaceAfterBar ^ carets
-      | true, true -> 
+      | true, true ->
         let error_substring = FastpackUtil.UTF8.sub line (loc.start.column) (loc._end.column - loc.start.column) in
         let colored_error = print_with_color error_substring Red in
         let colored_line = String.replace ~sub:error_substring ~by: colored_error line in
-        (print_with_color lineNo Red) ^ " │ " ^ colored_line  
-    ) codeframe in 
+        (print_with_color lineNo Red) ^ " │ " ^ colored_line
+    ) codeframe in
   String.concat "\n" formatted
 type reason =
   | CannotReadModule of string
@@ -118,24 +128,36 @@ let to_string package_dir error =
   | CannotLeavePackageDir filename ->
     Printf.sprintf
       "%s is out of the working directory\n"
-      filename 
+      filename
 
   | CannotResolveModule (_, dep) ->
-    let dep_str = Module.Dependency.to_string ~dir:(Some package_dir) dep in
-    let error_msg = "Cannot resolve request for " ^ dep_str in
+    let isTTY = FastpackUtil.FS.isatty Unix.stderr in
+    let (error_title, location) = format_error_header ~isTTY ~subtitle: ("cannot resolve '" ^ dep.request ^ "'") (
+        "Module resolution error:",
+        Module.location_to_string dep.requested_from
+      )
+    in
     (match List.assoc_opt dep.request nodelibs with
-     | None -> error_msg ^ "\n"
+     | None -> String.concat "\n" [
+         error_title;
+         location;
+       ]
      | Some None -> String.concat "\n" [
-         error_msg;
+         error_title;
+         location;
          "This looks like base node.js library which does not have any browser implementation we are aware of";
        ]
      | Some Some mock -> String.concat "\n" [
-         error_msg;
+         error_title;
+         location;
          "This looks like base node.js library and unlikely is required in the browser environment.";
          "If you still want to use it, first install the browser implementation with:";
-         Printf.sprintf "npm install --save %s" mock;
+         "";
+         Printf.sprintf "\t\tnpm install --save %s" mock;
+         "";
          "And then add this command line option when running fpack:";
-         Printf.sprintf "--mock %s:%s" dep.request mock;
+         "";
+         Printf.sprintf "\t\t--mock %s:%s" dep.request mock;
        ]
     )
 
@@ -144,28 +166,23 @@ let to_string package_dir error =
     let lines = String.split_on_char '\n' source
                 |> List.mapi (fun i line -> (i + 1, line)) in
 
-    let format_error isTTY (loc, error) = 
-      let error_desc = FlowParser.Parse_error.PP.error error in 
+    let format_error isTTY (loc, error) =
+      let error_desc = FlowParser.Parse_error.PP.error error in
       String.concat "\n" [
         "--------------------";
         error_desc ^ " at " ^ (loc_to_string loc);
         "";
         (get_codeframe ~isTTY loc lines);
-        ""; 
+        "";
       ]
     in
-    let (error_title, location) = 
-      if isTTY then
-        (print_with_color "Parse Error\n" Red, 
-         print_with_color ~font:Bold location_str Cyan)
-      else 
-        ("Parse Error\n", location_str) 
-    in
+    let (error_title, location) = format_error_header ~isTTY ("Parse error", location_str) in
     String.concat "\n" [
-      error_title ^ location;
+      error_title;
+      location;
       "";
       String.concat "\n" (List.map (format_error isTTY) errors);
-      ""; 
+      "";
     ]
 
   | NotImplemented (some_loc, message) ->

--- a/Fastpack/Error.ml
+++ b/Fastpack/Error.ml
@@ -2,7 +2,7 @@ module Loc = FlowParser.Loc
 module Scope = FastpackUtil.Scope
 
 (*
-  assoc list of nodejs libs and their mock implementations
+  assoc list of nodejs libs and their browser implementations
   as listed on: https://github.com/webpack/node-libs-browser
 *)
 let nodelibs = [

--- a/test/error-cannot-leave-package-dir/dev/stderr.txt
+++ b/test/error-cannot-leave-package-dir/dev/stderr.txt
@@ -1,10 +1,2 @@
 
-Project Directory: /.../test/error-cannot-leave-package-dir
-Mode: development
-Call Stack:
-	'../LeavePackageDir' from module: a.js	
-'./a' from module: index.js	
-'./index.js' from module: $fp$main
-Processing Module: a.js
-
 /.../test/LeavePackageDir.js is out of the working directory

--- a/test/error-cannot-leave-package-dir/dev/stderr.txt
+++ b/test/error-cannot-leave-package-dir/dev/stderr.txt
@@ -1,2 +1,3 @@
 
 /.../test/LeavePackageDir.js is out of the working directory
+

--- a/test/error-cannot-rename-module-binding/dev/stderr.txt
+++ b/test/error-cannot-rename-module-binding/dev/stderr.txt
@@ -1,12 +1,8 @@
 
-Project Directory: /.../test/error-cannot-rename-module-binding
-Mode: development
-Call Stack: (empty)
-Processing Module: $fp$main
 
-
-Cannot rename module binding:
-(3:9) - (3:10): a
-Import Request: './a' from module: index.js
-Typically, it means that you are trying to use the name before importing it in
+                            Cannot rename module binding:
+      (3:9) - (3:10): a
+        Import Request: './a' from module: index.js
+      Typically, it means that you are trying to use the name before importing it in
 the code.
+      

--- a/test/error-cannot-rename-module-binding/dev/stderr.txt
+++ b/test/error-cannot-rename-module-binding/dev/stderr.txt
@@ -1,8 +1,7 @@
 
-
-                            Cannot rename module binding:
-      (3:9) - (3:10): a
-        Import Request: './a' from module: index.js
-      Typically, it means that you are trying to use the name before importing it in
+Cannot rename module binding:
+(3:9) - (3:10): a
+Import Request: './a' from module: index.js
+Typically, it means that you are trying to use the name before importing it in
 the code.
-      
+

--- a/test/error-cannot-resolve-modules/dev/stderr.txt
+++ b/test/error-cannot-resolve-modules/dev/stderr.txt
@@ -1,2 +1,3 @@
 
-Cannot resolve request for './c' from module: index.js
+Module resolution error: cannot resolve './c'
+/.../test/error-cannot-resolve-modules/index.js

--- a/test/error-cannot-resolve-modules/dev/stderr.txt
+++ b/test/error-cannot-resolve-modules/dev/stderr.txt
@@ -1,21 +1,2 @@
 
-Project Directory: /.../test/error-cannot-resolve-modules
-Mode: development
-Call Stack:
-	'./index.js' from module: $fp$main
-Processing Module: index.js
-
-
-Cannot resolve module
-  Resolving './c'. Base directory: '/.../test/error-cannot-resolve-modules'
-  Resolving '/.../test/error-cannot-resolve-modules/c'.
-  File exists? '/.../test/error-cannot-resolve-modules/c'
-  ...no.
-  File exists? '/.../test/error-cannot-resolve-modules/c.js'
-  ...no.
-  File exists? '/.../test/error-cannot-resolve-modules/c.json'
-  ...no.
-  Is directory? '/.../test/error-cannot-resolve-modules/c'
-  ...no.
-While processing dependency request:
-	'./c' from module: index.js
+Cannot resolve request for './c' from module: index.js

--- a/test/error-cannot-resolve-node-module/dev.sh
+++ b/test/error-cannot-resolve-node-module/dev.sh
@@ -1,0 +1,1 @@
+$FPACK --dev index.js

--- a/test/error-cannot-resolve-node-module/dev.sh
+++ b/test/error-cannot-resolve-node-module/dev.sh
@@ -1,1 +1,2 @@
 $FPACK --dev index.js
+$FPACK --dev index2.js

--- a/test/error-cannot-resolve-node-module/dev/stderr.txt
+++ b/test/error-cannot-resolve-node-module/dev/stderr.txt
@@ -9,6 +9,7 @@ If you still want to use it, first install the browser implementation with:
 And then add this command line option when running fpack:
 
 		--mock url:url
+
 Module resolution error: cannot resolve 'dns'
 /.../test/error-cannot-resolve-node-module/index2.js
 This looks like base node.js library which does not have any browser implementation we are aware of

--- a/test/error-cannot-resolve-node-module/dev/stderr.txt
+++ b/test/error-cannot-resolve-node-module/dev/stderr.txt
@@ -1,0 +1,5 @@
+
+Cannot resolve request for 'url' from module: index.js
+This looks like base node.js library and unlikely is required in the browser environment.
+If you still want to use it, here is the suggested command line option:
+--mock url:defunctzombie/node-url

--- a/test/error-cannot-resolve-node-module/dev/stderr.txt
+++ b/test/error-cannot-resolve-node-module/dev/stderr.txt
@@ -2,4 +2,6 @@
 Cannot resolve request for 'url' from module: index.js
 This looks like base node.js library and unlikely is required in the browser environment.
 If you still want to use it, here is the suggested command line option:
---mock url:defunctzombie/node-url
+--mock url:url
+Cannot resolve request for 'dns' from module: index2.js
+This looks like base node.js library which does not have any browser implementation we are aware of

--- a/test/error-cannot-resolve-node-module/dev/stderr.txt
+++ b/test/error-cannot-resolve-node-module/dev/stderr.txt
@@ -1,7 +1,14 @@
 
-Cannot resolve request for 'url' from module: index.js
+Module resolution error: cannot resolve 'url'
+/.../test/error-cannot-resolve-node-module/index.js
 This looks like base node.js library and unlikely is required in the browser environment.
-If you still want to use it, here is the suggested command line option:
---mock url:url
-Cannot resolve request for 'dns' from module: index2.js
+If you still want to use it, first install the browser implementation with:
+
+		npm install --save url
+
+And then add this command line option when running fpack:
+
+		--mock url:url
+Module resolution error: cannot resolve 'dns'
+/.../test/error-cannot-resolve-node-module/index2.js
 This looks like base node.js library which does not have any browser implementation we are aware of

--- a/test/error-cannot-resolve-node-module/index.js
+++ b/test/error-cannot-resolve-node-module/index.js
@@ -1,0 +1,2 @@
+import stream from 'stream'; 
+import url from 'url'; 

--- a/test/error-cannot-resolve-node-module/index2.js
+++ b/test/error-cannot-resolve-node-module/index2.js
@@ -1,0 +1,1 @@
+import helloWorld from 'dns'; 

--- a/test/error-parse-tty/dev/stderr.txt
+++ b/test/error-parse-tty/dev/stderr.txt
@@ -1,11 +1,4 @@
 
-Project Directory: /.../test/error-parse-tty
-Mode: development
-Call Stack:
-	'./a' from module: index.js	
-'./index.js' from module: $fp$main
-Processing Module: a.js
-
 [0;31mParse Error
 [0m[1;36m/.../test/error-parse-tty/a.js[0m
 

--- a/test/error-parse-tty/dev/stderr.txt
+++ b/test/error-parse-tty/dev/stderr.txt
@@ -1,6 +1,6 @@
 
-[0;31mParse Error
-[0m[1;36m/.../test/error-parse-tty/a.js[0m
+[0;31mParse error[0m 
+[1;36m/.../test/error-parse-tty/a.js[0m
 
 --------------------
 Unexpected token ; at (3:14) - (3:15):

--- a/test/error-parse-tty/dev/stderr.txt
+++ b/test/error-parse-tty/dev/stderr.txt
@@ -18,3 +18,4 @@ Unexpected identifier at (10:6) - (10:11):
 [0;31m10[0m │ let a [0;31maaaaa[0m = 5;
 11 │ export default hello;
 
+

--- a/test/error-parse/dev/stderr.txt
+++ b/test/error-parse/dev/stderr.txt
@@ -20,3 +20,4 @@ Unexpected identifier at (10:6) - (10:11):
    │       ^^^^^
 11 │ export default hello;
 
+

--- a/test/error-parse/dev/stderr.txt
+++ b/test/error-parse/dev/stderr.txt
@@ -1,11 +1,4 @@
 
-Project Directory: /.../test/error-parse
-Mode: development
-Call Stack:
-	'./a' from module: index.js	
-'./index.js' from module: $fp$main
-Processing Module: a.js
-
 Parse Error
 /.../test/error-parse/a.js
 

--- a/test/error-parse/dev/stderr.txt
+++ b/test/error-parse/dev/stderr.txt
@@ -1,5 +1,5 @@
 
-Parse Error
+Parse error 
 /.../test/error-parse/a.js
 
 --------------------


### PR DESCRIPTION
Addresses point 3 of https://github.com/fastpack/fastpack/issues/95.

**summary**
Sometimes people will either directly or indirectly be reliant upon nodejs internal libs when writing code for the web. `webpack` [maintains a list](https://github.com/webpack/node-libs-browser) of mock and real implementations for when the functionality (or a mock of it) is needed.  We can utilize that list in order to provide more helpful error messages for when people run into these nodejs libs in their transitive dependencies (2nd level+ dependencies).

---

**before**
```
Project Directory: /.../test/errorcannotresolvemodules
Mode: development
Call Stack:
       './index.js' from module: $fp$main
Processing Module: index.js


Cannot resolve module
  Resolving './url'. Base directory: '/.../test/errorcannotresolvemodules'
  Resolving '/.../test/errorcannotresolvemodules/c'.
  File exists? '/.../test/errorcannotresolvemodules/c'
  ...no.
  File exists? '/.../test/errorcannotresolvemodules/c.js'
  ...no.
  File exists? '/.../test/errorcannotresolvemodules/c.json'
  ...no.
  Is directory? '/.../test/errorcannotresolvemodules/c'
  ...no.
While processing dependency request:
       './url' from module: index.js
```

**desired**

```
Cannot resolve request for 'url' from module: index.js
This looks like base node.js library and unlikely is required in the browser environment.
If you still want to use it, here is the suggested command line option:
--mock url:defunctzombie/node-url
```