### PR TITLE
DevServer: misc. slight improvements

### DIFF
--- a/Fastpack/Commands.re
+++ b/Fastpack/Commands.re
@@ -101,13 +101,13 @@ module Watch = {
 };
 
 module Serve = {
-  let run = (options: Config.t) =>
+  let run = (options: Config.t, serverConfig: FastpackServer.Config.t) =>
     run(options.debug, () =>
       Lwt_main.run(
         {
           let (broadcastToWebsocket, devserver) =
             FastpackServer.Devserver.start(
-              ~port=options.port,
+              ~config=serverConfig,
               ~outputDir=options.outputDir,
               ~debug=options.debug,
               (),
@@ -178,7 +178,7 @@ module Serve = {
   let command =
     register((
       /* TODO: add options here */
-      Term.(ret(const(run) $ Config.term)),
+      Term.(ret(const(run) $ Config.term $ FastpackServer.Config.term)),
       Term.info("serve", ~doc, ~sdocs, ~exits),
     ));
 };

--- a/Fastpack/Commands.re
+++ b/Fastpack/Commands.re
@@ -107,7 +107,7 @@ module Serve = {
         {
           let (broadcastToWebsocket, devserver) =
             FastpackServer.Devserver.start(
-              ~port=3000,
+              ~port=options.port,
               ~outputDir=options.outputDir,
               ~debug=options.debug,
               (),

--- a/Fastpack/Config.re
+++ b/Fastpack/Config.re
@@ -105,6 +105,7 @@ type t = {
   nodeModulesPaths: list(string),
   outputDir: string,
   outputFilename: string,
+  port: int,
   postprocess: list(string),
   preprocess: list(Preprocessor.t),
   projectRootDir: string,
@@ -126,6 +127,7 @@ let create =
       ~target,
       ~cache,
       ~preprocess,
+      ~port,
       ~postprocess,
       ~report,
       ~debug,
@@ -172,6 +174,7 @@ let create =
     nodeModulesPaths,
     outputDir,
     outputFilename,
+    port,
     postprocess,
     preprocess,
     projectRootDir,
@@ -192,6 +195,7 @@ let term = {
         nodeModulesPaths,
         outputDir,
         outputFilename,
+        port,
         postprocess,
         preprocess,
         projectRootDir,
@@ -208,6 +212,7 @@ let term = {
       ~nodeModulesPaths,
       ~outputDir,
       ~outputFilename,
+      ~port,
       ~postprocess,
       ~preprocess=List.map(snd, preprocess),
       ~projectRootDir,
@@ -314,6 +319,12 @@ let term = {
     Arg.(value & vflag(Cache.Use, [disable]));
   };
 
+  let portT = {
+    let doc = "Port for development server to listen on";
+    let docv = "NUMBER";
+    Arg.( value & opt(int, 3000) & info(["p", "port"], ~docv, ~doc));
+  }
+
   let preprocessT = {
     let preprocess = Arg.conv(Preprocessor.(parse, print));
 
@@ -362,19 +373,20 @@ let term = {
 
   Term.(
     const(run)
+    $ cacheT
+    $ debugT
     $ entryPointsT
+    $ mockT
+    $ modeT
+    $ nodeModulesPathsT
     $ outputDirT
     $ outputFilenameT
-    $ modeT
-    $ mockT
-    $ nodeModulesPathsT
+    $ portT
+    $ postprocessT
+    $ preprocessT
     $ projectRootDirT
+    $ reportT
     $ resolveExtensionT
     $ targetT
-    $ cacheT
-    $ preprocessT
-    $ postprocessT
-    $ reportT
-    $ debugT
   );
 };

--- a/Fastpack/Config.re
+++ b/Fastpack/Config.re
@@ -97,20 +97,20 @@ module Preprocessor = {
 };
 
 type t = {
+  cache: Cache.t,
+  debug: bool,
   entryPoints: list(string),
+  mock: list((string, Mock.t)),
+  mode: Mode.t,
+  nodeModulesPaths: list(string),
   outputDir: string,
   outputFilename: string,
-  mode: Mode.t,
-  mock: list((string, Mock.t)),
-  nodeModulesPaths: list(string),
+  postprocess: list(string),
+  preprocess: list(Preprocessor.t),
   projectRootDir: string,
+  report: Reporter.t,
   resolveExtension: list(string),
   target: Target.t,
-  cache: Cache.t,
-  preprocess: list(Preprocessor.t),
-  postprocess: list(string),
-  report: Reporter.t,
-  debug: bool,
 };
 
 let create =
@@ -164,56 +164,56 @@ let create =
          }
        );
   {
+    cache,
+    debug,
     entryPoints,
+    mock,
+    mode,
+    nodeModulesPaths,
     outputDir,
     outputFilename,
-    mode,
-    mock,
-    nodeModulesPaths,
+    postprocess,
+    preprocess,
     projectRootDir,
+    report,
     resolveExtension,
     target,
-    cache,
-    preprocess,
-    postprocess,
-    report,
-    debug,
   };
 };
 
 let term = {
   let run =
       (
+        cache,
+        debug,
         entryPoints,
+        mock,
+        mode,
+        nodeModulesPaths,
         outputDir,
         outputFilename,
-        mode,
-        mock,
-        nodeModulesPaths,
+        postprocess,
+        preprocess,
         projectRootDir,
+        report,
         resolveExtension,
         target,
-        cache,
-        preprocess,
-        postprocess,
-        report,
-        debug,
       ) =>
     create(
+      ~cache,
+      ~debug,
       ~entryPoints,
+      ~mock=List.map(snd, mock),
+      ~mode,
+      ~nodeModulesPaths,
       ~outputDir,
       ~outputFilename,
-      ~mode,
-      ~mock=List.map(snd, mock),
-      ~nodeModulesPaths,
+      ~postprocess,
+      ~preprocess=List.map(snd, preprocess),
       ~projectRootDir,
+      ~report,
       ~resolveExtension,
       ~target,
-      ~cache,
-      ~preprocess=List.map(snd, preprocess),
-      ~postprocess,
-      ~report,
-      ~debug,
     );
 
   let entryPointsT = {

--- a/Fastpack/Config.re
+++ b/Fastpack/Config.re
@@ -105,7 +105,6 @@ type t = {
   nodeModulesPaths: list(string),
   outputDir: string,
   outputFilename: string,
-  port: int,
   postprocess: list(string),
   preprocess: list(Preprocessor.t),
   projectRootDir: string,
@@ -127,7 +126,6 @@ let create =
       ~target,
       ~cache,
       ~preprocess,
-      ~port,
       ~postprocess,
       ~report,
       ~debug,
@@ -174,7 +172,6 @@ let create =
     nodeModulesPaths,
     outputDir,
     outputFilename,
-    port,
     postprocess,
     preprocess,
     projectRootDir,
@@ -195,7 +192,6 @@ let term = {
         nodeModulesPaths,
         outputDir,
         outputFilename,
-        port,
         postprocess,
         preprocess,
         projectRootDir,
@@ -212,7 +208,6 @@ let term = {
       ~nodeModulesPaths,
       ~outputDir,
       ~outputFilename,
-      ~port,
       ~postprocess,
       ~preprocess=List.map(snd, preprocess),
       ~projectRootDir,
@@ -319,12 +314,6 @@ let term = {
     Arg.(value & vflag(Cache.Use, [disable]));
   };
 
-  let portT = {
-    let doc = "Port for development server to listen on";
-    let docv = "NUMBER";
-    Arg.( value & opt(int, 3000) & info(["p", "port"], ~docv, ~doc));
-  }
-
   let preprocessT = {
     let preprocess = Arg.conv(Preprocessor.(parse, print));
 
@@ -381,7 +370,6 @@ let term = {
     $ nodeModulesPathsT
     $ outputDirT
     $ outputFilenameT
-    $ portT
     $ postprocessT
     $ preprocessT
     $ projectRootDirT

--- a/Fastpack/Error.re
+++ b/Fastpack/Error.re
@@ -1,6 +1,8 @@
 module Loc = Flow_parser.Loc;
 module Scope = FastpackUtil.Scope;
 
+open FastpackUtil.Colors;
+
 /*
    assoc list of nodejs libs and their browser implementations
    as listed on: https://github.com/webpack/node-libs-browser
@@ -40,37 +42,6 @@ let nodelibs = [
   ("vm", Some("vm-browserify")),
   ("zlib", Some("browserify-zlib")),
 ];
-
-type color =
-  | Cyan
-  | Red
-  | Black
-  | White;
-type font =
-  | Regular
-  | Bold;
-
-let print_with_color = (~font=Regular, ~isTTY=true, str, col) => {
-  let col =
-    switch (col) {
-    | Cyan => "36"
-    | Red => "31"
-    | Black => "30"
-    | White => "37"
-    };
-
-  let f =
-    switch (font) {
-    | Regular => "0"
-    | Bold => "1"
-    };
-
-  if (isTTY) {
-    "\027[" ++ f ++ ";" ++ col ++ "m" ++ str ++ "\027[0m";
-  } else {
-    str;
-  };
-};
 
 let format_error_header = (~isTTY=true, ~subtitle="", (title, path)) =>
   if (isTTY) {

--- a/FastpackServer/Config.re
+++ b/FastpackServer/Config.re
@@ -1,0 +1,13 @@
+open Cmdliner;
+
+type t = {port: int};
+let portT = {
+  let doc = "Port for development server to listen on";
+  let docv = "NUMBER";
+  Arg.(value & opt(int, 3000) & info(["p", "port"], ~docv, ~doc));
+};
+
+let term = {
+  let run = port => {port: port};
+  Term.(const(run) $ portT);
+};

--- a/FastpackServer/Devserver.re
+++ b/FastpackServer/Devserver.re
@@ -16,8 +16,8 @@ let createCallback =
   };
 };
 
-let start = (~port=3000, ~outputDir, ~debug, ()) => {
-  let url = "http://localhost:" ++ string_of_int(port);
+let start = (~config: Config.t, ~outputDir, ~debug, ()) => {
+  let url = "http://localhost:" ++ string_of_int(config.port);
   let urlWithColor =
     FastpackUtil.Colors.print_with_color(~font=Bold, url, Cyan);
   Printf.sprintf("Server running at %s", urlWithColor) |> print_endline;
@@ -27,7 +27,7 @@ let start = (~port=3000, ~outputDir, ~debug, ()) => {
 
   let server =
     Cohttp_lwt_unix.Server.create(
-      ~mode=`TCP(`Port(port)),
+      ~mode=`TCP(`Port(config.port)),
       Cohttp_lwt_unix.Server.make(
         ~callback=createCallback(~outputDir, ~websocketHandler),
         (),

--- a/FastpackServer/Devserver.re
+++ b/FastpackServer/Devserver.re
@@ -17,7 +17,7 @@ let createCallback =
 };
 
 let start = (~port=3000, ~outputDir, ~debug, ()) => {
-  Printf.sprintf("Listening on port %d...", port) |> print_endline;
+  Printf.sprintf("Server running at http://localhost:%d", port) |> print_endline;
 
   let (broadcastToWebsocket, websocketHandler) =
     WebsocketHandler.makeHandler(~debug, ());

--- a/FastpackServer/Devserver.re
+++ b/FastpackServer/Devserver.re
@@ -17,7 +17,10 @@ let createCallback =
 };
 
 let start = (~port=3000, ~outputDir, ~debug, ()) => {
-  Printf.sprintf("Server running at http://localhost:%d", port) |> print_endline;
+  let url = "http://localhost:" ++ string_of_int(port);
+  let urlWithColor =
+    FastpackUtil.Colors.print_with_color(~font=Bold, url, Cyan);
+  Printf.sprintf("Server running at %s", urlWithColor) |> print_endline;
 
   let (broadcastToWebsocket, websocketHandler) =
     WebsocketHandler.makeHandler(~debug, ());

--- a/FastpackUtil/Colors.re
+++ b/FastpackUtil/Colors.re
@@ -1,0 +1,31 @@
+type color =
+  | Cyan
+  | Red
+  | Black
+  | White;
+
+type font =
+  | Regular
+  | Bold;
+
+let print_with_color = (~font=Regular, ~isTTY=true, str, col) => {
+  let col =
+    switch (col) {
+    | Cyan => "36"
+    | Red => "31"
+    | Black => "30"
+    | White => "37"
+    };
+
+  let f =
+    switch (font) {
+    | Regular => "0"
+    | Bold => "1"
+    };
+
+  if (isTTY) {
+    "\027[" ++ f ++ ";" ++ col ++ "m" ++ str ++ "\027[0m";
+  } else {
+    str;
+  };
+};

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ COMMANDS
        watch
            watch for file changes and rebuild the bundle
 
+       worker
+           worker subprocess (do not use directly)
+
 ARGUMENTS
        ENTRY POINTS
            Entry points. Default: ['.']
@@ -74,8 +77,8 @@ OPTIONS
            Build bundle for development
 
        --dry-run
-           Run all the build operations without storing the bundle in the
-           file system
+           Run all the build operations without storing the bundle in the file
+           system
 
        --mock=PACKAGE[:SUBSTITUTE]
            Mock PACKAGE requests with SUBSTITUTE requests. If SUBSTITUTE is
@@ -93,6 +96,9 @@ OPTIONS
 
        -o DIR, --output=DIR (absent=./bundle)
            Output Directory. The target bundle will be DIR/index.js.
+
+       -p NUMBER, --port=NUMBER (absent=3000)
+           Port for development server to listen on
 
        --postprocess=COMMAND
            Apply shell command on a bundle file. The content of the bundle


### PR DESCRIPTION
This PR mainly seeks to enable the selection of a `port` instead of locking the user into 3000.
The ability to select a port was already available in the DevServer modules yet just wasn't exposed via `Cmdliner` options.

Misc. other changes:

1. Add the `--port ` flag to be able to modify the port that fpack devserver runs on
2. Update the `README.md` with the latest documentation from `--help` (including the new port option)
3. Modified the server's startup message so that it includes a link to the running server. Also makes it more colorful.
4. Moved the `print_with_color` helper function from the `FastPack` directory to a new file in `FastPackUtils` since it now gets used from both `FastPack` and from `FastPackDevsever`
4. (controversial) alphabetically sorted the keys used in `Config.t` -- let me know if you'd like me to undo this. 

**screenshot**

![screen shot 2018-10-08 at 8 37 25 am](https://user-images.githubusercontent.com/4656974/46609303-7d125b80-cad5-11e8-91d2-82414a67d593.png)
