### PR TITLE
refactor: add Pastel into Terminal.print_with_color

### DIFF
--- a/Fastpack/Commands.re
+++ b/Fastpack/Commands.re
@@ -3,6 +3,7 @@ module FS = FastpackUtil.FS;
 module Terminal = FastpackUtil.Terminal;
 module StringSet = Set.Make(CCString);
 open Cmdliner;
+open Pastel;
 
 let exits = Term.default_exits;
 let sdocs = Manpage.s_common_options;

--- a/Fastpack/Commands.re
+++ b/Fastpack/Commands.re
@@ -3,7 +3,6 @@ module FS = FastpackUtil.FS;
 module Terminal = FastpackUtil.Terminal;
 module StringSet = Set.Make(CCString);
 open Cmdliner;
-open Pastel;
 
 let exits = Term.default_exits;
 let sdocs = Manpage.s_common_options;
@@ -87,19 +86,13 @@ let reportResult = (start_time, result, builder) =>
           sprintf("%db", size);
         }
       );
-    let report =
-      Terminal.(
-        print_with_color(
-          ~font=Bold,
-          ~color=Green,
-          Printf.sprintf(
-            "Done in %.3fs. Bundle: %s. Modules: %d.\n",
-            Unix.gettimeofday() -. start_time,
-            pretty_size,
-            modules,
-          ),
-        )
-      );
+    let reportContent = Printf.sprintf(
+      "Done in %.3fs. Bundle: %s. Modules: %d.\n",
+      Unix.gettimeofday() -. start_time,
+      pretty_size,
+      modules
+    )
+    let report = Pastel.(<Pastel bold=true color=Green>reportContent</Pastel>)
     Lwt_io.(write_line(stdout, report));
   };
 
@@ -274,11 +267,7 @@ It looks, like your system doesn't have it installed. Please, check here
 for installation instructions:
   https://facebook.github.io/watchman/
           |},
-                  Terminal.print_with_color(
-                    ~font=Bold,
-                    ~color=Red,
-                    "Cannot start file watching service: watchman",
-                  ),
+                  Pastel.(<Pastel bold=true color=Red>"Cannot start file watching service: watchman"</Pastel>),
                   msg,
                 ),
               ),

--- a/Fastpack/Error.re
+++ b/Fastpack/Error.re
@@ -2,6 +2,8 @@ module Loc = Flow_parser.Loc;
 module Scope = FastpackUtil.Scope;
 module Terminal = FastpackUtil.Terminal;
 
+open Pastel;
+
 /*
    assoc list of nodejs libs and their browser implementations
    as listed on: https://github.com/webpack/node-libs-browser

--- a/Fastpack/Error.re
+++ b/Fastpack/Error.re
@@ -1,8 +1,5 @@
 module Loc = Flow_parser.Loc;
 module Scope = FastpackUtil.Scope;
-module Terminal = FastpackUtil.Terminal;
-
-open Pastel;
 
 /*
    assoc list of nodejs libs and their browser implementations
@@ -77,14 +74,10 @@ module CannotResolveModuleError = {
 };
 
 let formatErrorHeader = (~where="", text) =>
-  String.concat(
-    "\n",
-    [
-      Terminal.print_with_color(~font=Bold, ~color=Cyan, where),
-      Terminal.print_with_color(~color=Red, text),
-      "",
-    ],
-  );
+  <Pastel>
+    <Pastel bold=true color=Cyan>where</Pastel>
+    <Pastel color=Red>text</Pastel>
+  </Pastel>
 
 let get_codeframe = (loc: Loc.t, lines) => {
   let isTTY = FastpackUtil.FS.isatty(Unix.stderr);
@@ -134,14 +127,14 @@ let get_codeframe = (loc: Loc.t, lines) => {
               loc._end.column - loc.start.column,
             );
           if (String.length(error_substring) > 0) {
-            let colored_error =
-              Terminal.print_with_color(~color=Red, error_substring);
+            let colored_error = <Pastel color=Red>error_substring</Pastel>;
             Logs.debug(x =>
               x("e: %s ... colo: %s", error_substring, colored_error)
             );
             let colored_line =
               CCString.replace(~sub=error_substring, ~by=colored_error, line);
-            Terminal.print_with_color(~color=Red, lineNo)
+
+            <Pastel color=Red>error_substring</Pastel>
             ++ " │ "
             ++ colored_line;
           } else {

--- a/FastpackUtil/Terminal.re
+++ b/FastpackUtil/Terminal.re
@@ -1,26 +1,8 @@
-type font =
-  | Regular
-  | Bold;
-
-let print_with_color = (~font=Regular, ~color, str) => {
-  let isTTY = FS.isatty(Unix.stderr);
-
-  let f =
-    switch (font) {
-    | Regular => false
-    | Bold => true
-    };
-
-  if (isTTY) {
-    <Pastel bold=f color={color}>str</Pastel>
-  } else {
-    str;
-  };
-};
-
 let clearScreen = () =>
   switch (FS.isatty(Unix.stdout)) {
   | false => Lwt.return_unit
-  | true => let _ = Unix.system("clear"); Lwt.return_unit
+  | true =>
+    let _ = Unix.system("clear");
+    Lwt.return_unit;
   /* Lwt_io.(write(stdout, "\\033[2J\\033[1;1H")) */
   };

--- a/FastpackUtil/Terminal.re
+++ b/FastpackUtil/Terminal.re
@@ -1,33 +1,18 @@
-type color =
-  | Black
-  | Red
-  | Green
-  | Cyan
-  | White;
-
 type font =
   | Regular
   | Bold;
 
 let print_with_color = (~font=Regular, ~color, str) => {
   let isTTY = FS.isatty(Unix.stderr);
-  let col =
-    switch (color) {
-    | Black => "30"
-    | Red => "31"
-    | Green => "32"
-    | Cyan => "36"
-    | White => "37"
-    };
 
   let f =
     switch (font) {
-    | Regular => "0"
-    | Bold => "1"
+    | Regular => false
+    | Bold => true
     };
 
   if (isTTY) {
-    "\027[" ++ f ++ ";" ++ col ++ "m" ++ str ++ "\027[0m";
+    <Pastel bold=f color={color}>str</Pastel>
   } else {
     str;
   };

--- a/FastpackUtil/dune
+++ b/FastpackUtil/dune
@@ -1,7 +1,7 @@
 (library
  (name        FastpackUtil)
   (public_name FastpackUtil)
-  (libraries lwt.unix fileutils yojson containers str flow_parser logs logs.cli logs.lwt fmt re re.posix)
+  (libraries lwt.unix fileutils yojson containers str flow_parser logs logs.cli logs.lwt fmt re re.posix pastel.lib)
   (c_names sysutil)
   (c_flags (:include config/c_link_flags.sexp))
   (preprocess (pps lwt_ppx)))


### PR DESCRIPTION
Hey @zindel 

I started by refactoring the `print_with_color` with Pastel, to avoid too many changes into all the reports to stdout/stderr.

Didn't want to remove `clearScreen` yet without Windows testing, yet.
